### PR TITLE
Fix security issue in dynamic links

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -55,7 +55,7 @@ function renderItems(items, type) {
                     <p class="text-muted"><span class="font-weight-bold">${item.title}</span>&nbsp;&nbsp;
                         ${item.description}</p>
                     <div class="container text-center btn-container">
-                        <a class="btn btn-primary" href="${item.link}" target="_blank">${item.linkText}</a>
+                        <a class="btn btn-primary" href="${item.link}" target="_blank" rel="noopener noreferrer">${item.linkText}</a>
                     </div>
                 </div>
             `;


### PR DESCRIPTION
## Summary
- fix potential reverse tabnabbing issue by adding `rel="noopener noreferrer"` to dynamically generated external links

## Testing
- `jq empty assets/data/projects.json`
- `jq empty assets/data/research.json`


------
https://chatgpt.com/codex/tasks/task_e_683f4385e9fc8326b720eaa560dd1fb8