### PR TITLE
Upgrade site to Bootstrap 5

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -52,7 +52,7 @@ function renderItems(items, type) {
                                  src="${item.imgSrc}" title="${item.title}" loading="lazy"/>
                         </picture>
                     </div>
-                    <p class="text-muted"><span class="font-weight-bold">${item.title}</span>&nbsp;&nbsp;
+                    <p class="text-muted"><span class="fw-bold">${item.title}</span>&nbsp;&nbsp;
                         ${item.description}</p>
                     <div class="container text-center btn-container">
                         <a class="btn btn-primary" href="${item.link}" target="_blank" rel="noopener noreferrer">${item.linkText}</a>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,8 @@
     <title>Lou Schlessinger</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
+          integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
@@ -141,7 +142,9 @@
      ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+<script crossorigin="anonymous"
+        integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
+        src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 <script src="assets/js/main.js"></script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -41,8 +41,7 @@
     <title>Lou Schlessinger</title>
 
     <!-- Bootstrap core CSS -->
-    <link crossorigin="anonymous" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
-          integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
@@ -53,13 +52,13 @@
     <link href="assets/ico/site.webmanifest" rel="manifest">
 </head>
 
-<body data-offset="50" data-spy="scroll" data-target=".navbar">
+<body data-bs-spy="scroll" data-bs-target="#main-navbar" data-bs-offset="50" tabindex="0">
 <main>
     <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark" id="main-navbar">
         <a class="navbar-brand" href="#intro-section">Lou Schlessinger</a>
         <button aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation"
                 class="navbar-toggler"
-                data-target="#navbarCollapse" data-toggle="collapse" type="button">
+                data-bs-target="#navbarCollapse" data-bs-toggle="collapse" type="button">
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse justify-content-end" id="navbarCollapse">
@@ -142,12 +141,7 @@
      ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-<script crossorigin="anonymous"
-        integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
-        src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"></script>
-<script crossorigin="anonymous"
-        integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
-        src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 <script src="assets/js/main.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- use Bootstrap 5 CSS and JS bundle
- switch data attributes to `data-bs-*`
- update classes to match Bootstrap 5 (`fw-bold`)
- document the stack without referencing Bootstrap version

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f6eb7e3e08326944d9370d29c1d1b