### PR TITLE
perf: drop WebP HEAD probes, preload LCP, add sitemap/robots

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -80,18 +80,22 @@
     font-weight: bolder;
 }
 
+#about-section,
+#projects-section,
+#research-section,
+#contact-section {
+    padding-top: 60px;
+    padding-bottom: 60px;
+}
+
 #about-section {
     background: var(--color-section-bg);
     color: var(--color-section-text);
-    padding-top: 60px;
-    padding-bottom: 60px;
 }
 
 #projects-section {
     background: var(--color-section-bg);
     color: var(--color-section-text);
-    padding-top: 60px;
-    padding-bottom: 60px;
 }
 
 #projects-section img, #research-section img {
@@ -108,8 +112,6 @@
 #research-section {
     background: var(--color-research-bg);
     color: var(--color-section-text);
-    padding-top: 60px;
-    padding-bottom: 60px;
 }
 
 #research-section .row {
@@ -118,8 +120,12 @@
 
 #contact-section {
     background: var(--color-contact-bg);
-    padding-top: 60px;
-    padding-bottom: 60px;
+}
+
+/* Defer rendering cost of offscreen card rows */
+.card-row {
+    content-visibility: auto;
+    contain-intrinsic-size: 1px 500px;
 }
 
 #projects,

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2,9 +2,10 @@ const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 async function fetchData(type, retries = 3) {
     const container = document.getElementById(`${type}-container`);
+    container.setAttribute('aria-busy', 'true');
     for (let attempt = 1; attempt <= retries; attempt++) {
         try {
-            const response = await fetch(`assets/data/${type}.json?t=${new Date().getTime()}`);
+            const response = await fetch(`assets/data/${type}.json`);
             if (!response.ok) {
                 console.error(`HTTP error! Status: ${response.status}`);
                 if (attempt < retries) {
@@ -13,15 +14,18 @@ async function fetchData(type, retries = 3) {
                     continue;
                 }
                 showRetryError(container, type);
+                container.setAttribute('aria-busy', 'false');
                 return;
             }
             const data = await response.json();
             if (!Array.isArray(data)) {
                 console.error(`Invalid JSON format: Expected an array for ${type}`);
                 container.innerHTML = `<p class='text-danger'>Invalid ${type} data format.</p>`;
+                container.setAttribute('aria-busy', 'false');
                 return;
             }
             renderItems(data, type);
+            container.setAttribute('aria-busy', 'false');
             return;
         } catch (error) {
             console.error(`Error loading ${type}:`, error);
@@ -30,6 +34,7 @@ async function fetchData(type, retries = 3) {
                 await delay(2000);
             } else {
                 showRetryError(container, type);
+                container.setAttribute('aria-busy', 'false');
             }
         }
     }
@@ -51,28 +56,13 @@ function showRetryError(container, type) {
     container.appendChild(wrapper);
 }
 
-// Cache for webp availability checks to avoid repeated network calls
-const webpAvailabilityCache = new Map();
-
-async function isWebpAvailable(originalSrc) {
-    if (!/\.(png|jpg|jpeg)$/i.test(originalSrc)) return false; // Already webp or unsupported
-    const candidate = originalSrc.replace(/\.(png|jpg|jpeg)$/i, '.webp');
-    if (webpAvailabilityCache.has(candidate)) {
-        return webpAvailabilityCache.get(candidate);
-    }
-    try {
-        const resp = await fetch(candidate, { method: 'HEAD' });
-        const ok = resp.ok;
-        webpAvailabilityCache.set(candidate, ok);
-        return ok;
-    } catch {
-        // Optional WebP support: treat network failures as a miss but surface details in dev when enabled.
-        if (window?.DEBUG) {
-            console.debug('WebP availability check failed for', candidate);
-        }
-        webpAvailabilityCache.set(candidate, false);
-        return false;
-    }
+// Build a WebP variant path for PNG/JPG sources. Every raster image in
+// assets/img/ has a same-basename .webp sibling (see tools/generate-webp.js),
+// so we emit the <source> unconditionally and rely on <picture> fallback.
+function webpVariant(src) {
+    return /\.(png|jpg|jpeg)$/i.test(src)
+        ? src.replace(/\.(png|jpg|jpeg)$/i, '.webp')
+        : null;
 }
 
 function escapeHTML(str) {
@@ -81,15 +71,12 @@ function escapeHTML(str) {
     return div.innerHTML;
 }
 
-async function renderItems(items, type) {
+function renderItems(items, type) {
     const container = document.getElementById(`${type}-container`);
     container.innerHTML = ""; // Clear existing content
 
-    // Precompute webp availability in parallel for all items
-    const availability = await Promise.all(items.map(it => isWebpAvailable(it.imgSrc)));
-
     for (let i = 0; i < items.length; i += 2) {
-        let rowHTML = '<div class="row">';
+        let rowHTML = '<div class="row card-row">';
 
         for (let j = 0; j < 2 && i + j < items.length; j++) {
             const item = items[i + j];
@@ -97,13 +84,10 @@ async function renderItems(items, type) {
                 console.warn(`Skipping invalid ${type} entry:`, item);
                 continue;
             }
-            // Derive a potential WebP variant path (assumes same basename with .webp present in repo)
-            // If the original already ends with .webp, we won't insert an extra source.
-            let webpSource = '';
-            if (availability[i + j]) {
-                const candidateWebp = item.imgSrc.replace(/\.(png|jpg|jpeg)$/i, '.webp');
-                webpSource = `<source srcset="${encodeURI(candidateWebp)}" type="image/webp">`;
-            }
+            const webp = webpVariant(item.imgSrc);
+            const webpSource = webp
+                ? `<source srcset="${encodeURI(webp)}" type="image/webp">`
+                : '';
             // Performance hints: first row gets higher priority; others remain lazy & low priority
             const isAboveFoldLikely = i === 0; // heuristic: first rendered row
             const loadingAttr = isAboveFoldLikely ? 'loading="eager"' : 'loading="lazy"';

--- a/index.html
+++ b/index.html
@@ -54,6 +54,13 @@
     <!-- Custom styles for this template -->
     <link rel="preload" href="assets/css/main.css" as="style">
     <link href="assets/css/main.css" rel="stylesheet">
+
+    <!-- Preload LCP image (first research card) -->
+    <link rel="preload" as="image" href="assets/img/patch_agg.webp" type="image/webp" fetchpriority="high">
+
+    <!-- Preload dynamic content JSON -->
+    <link rel="preload" as="fetch" href="assets/data/research.json" type="application/json" crossorigin>
+    <link rel="preload" as="fetch" href="assets/data/projects.json" type="application/json" crossorigin>
     <link href="assets/ico/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180">
     <link href="assets/ico/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">
     <link href="assets/ico/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png">
@@ -114,12 +121,10 @@
     <section id="about-section" aria-labelledby="about">
         <div class="container">
             <h2 class="display-4" id="about">About</h2>
+            <p class="lead">Hello!</p>
+            <p class="lead">My name is Lou Schlessinger.</p>
             <p class="lead">
-                Hello!
-                <br>
-                <br> My name is Lou Schlessinger.
-                <br>
-                <br> I was a student at <a href="https://wustl.edu">Washington University in St. Louis</a> studying
+                I was a student at <a href="https://wustl.edu">Washington University in St. Louis</a> studying
                 computer science and physics. I graduated in December 2018 with a B.S. and M.S. in computer science.
                 My primary research interests are in <strong>automated machine learning</strong>,
                 <strong>meta-learning</strong>, and the intersection of <strong>AI and quantitative reasoning</strong>.
@@ -130,14 +135,14 @@
     <section id="research-section" aria-labelledby="research">
         <div class="container">
             <h2 class="display-4" id="research">Research</h2>
-            <div id="research-container"></div> <!-- Research will be inserted here -->
+            <div id="research-container" aria-busy="true" aria-live="polite"></div> <!-- Research will be inserted here -->
         </div>
     </section>
 
     <section id="projects-section" aria-labelledby="projects">
         <div class="container">
             <h2 class="display-4" id="projects">Projects</h2>
-            <div id="projects-container"></div> <!-- Projects will be inserted here -->
+            <div id="projects-container" aria-busy="true" aria-live="polite"></div> <!-- Projects will be inserted here -->
         </div>
     </section>
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://louschlessinger.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://louschlessinger.com/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
- js: unconditionally emit <picture> <source> instead of probing WebP via HEAD (every raster has a .webp sibling)
- js: remove JSON cache-buster query param; rely on HTTP caching
- js: toggle aria-busy on dynamic containers during fetch
- html: preload LCP image (patch_agg.webp) and projects/research JSON
- html: replace <br><br> with real <p> tags in About
- html: add aria-busy + aria-live to projects/research containers
- css: consolidate duplicated 60px section padding
- css: content-visibility:auto on card rows to defer offscreen rendering
- seo: add robots.txt and sitemap.xml