### PR TITLE
seo: improve name discoverability and metadata

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -17,6 +17,7 @@
     --color-card-text: #6c757d;
     --color-social-icon: #333;
     --color-link: #0d6efd;
+    --color-name-muted: #5c636a;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -38,6 +39,7 @@
         --color-card-text: #d1d5db;
         --color-social-icon: #d1d5db;
         --color-link: #60a5fa;
+        --color-name-muted: #9ca3af;
     }
 }
 
@@ -78,6 +80,11 @@
 
 #tagline {
     font-weight: bolder;
+}
+
+/* Muted "(is)" in the Lou(is) wordplay (About section) */
+.name-muted {
+    color: var(--color-name-muted);
 }
 
 #about-section,

--- a/index.html
+++ b/index.html
@@ -14,31 +14,31 @@
 
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
-    <meta name="description" content="Portfolio of Louis (Lou) Schlessinger.">
+    <meta name="description" content="Louis (Lou) Schlessinger — machine learning engineer and researcher, Vesuvius Challenge Grand Prize runner-up, focused on AutoML and meta-learning.">
     <link rel="canonical" href="https://louschlessinger.com/">
     <meta content="Louis Schlessinger" name="author">
     <meta name="theme-color" content="#111827">
 
     <!-- SEO & Open Graph -->
     <meta content="index, follow" name="robots">
-    <meta content="Lou Schlessinger" property="og:title">
-    <meta content="Portfolio website for Lou Schlessinger." property="og:description">
-    <meta content="https://louschlessinger.com" property="og:url">
+    <meta content="Louis (Lou) Schlessinger — Machine Learning Engineer" property="og:title">
+    <meta content="Louis (Lou) Schlessinger — machine learning engineer and researcher, Vesuvius Challenge Grand Prize runner-up, focused on AutoML and meta-learning." property="og:description">
+    <meta content="https://louschlessinger.com/" property="og:url">
     <meta content="website" property="og:type">
     <meta content="https://louschlessinger.com/assets/img/scroll.png" property="og:image">
     <meta content="Ink detection visualization from the Vesuvius Challenge Grand Prize runner-up submission." property="og:image:alt">
-    <meta content="Lou Schlessinger" property="og:site_name">
+    <meta content="Louis Schlessinger" property="og:site_name">
     <meta content="en_US" property="og:locale">
 
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Lou Schlessinger">
-    <meta name="twitter:description" content="Portfolio website for Lou Schlessinger.">
+    <meta name="twitter:title" content="Louis (Lou) Schlessinger — Machine Learning Engineer">
+    <meta name="twitter:description" content="Louis (Lou) Schlessinger — machine learning engineer and researcher, Vesuvius Challenge Grand Prize runner-up, focused on AutoML and meta-learning.">
     <meta name="twitter:image" content="https://louschlessinger.com/assets/img/scroll.png">
     <meta name="twitter:image:alt" content="Ink detection visualization from the Vesuvius Challenge Grand Prize runner-up submission.">
     <meta name="twitter:url" content="https://louschlessinger.com/">
 
     <link href="assets/ico/favicon.ico" rel="icon" type="image/x-icon">
-    <title>Lou Schlessinger</title>
+    <title>Louis (Lou) Schlessinger — Machine Learning Engineer</title>
 
     <!-- Preconnect to CDN origins for faster resource loading -->
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -70,18 +70,20 @@
             "@context": "https://schema.org",
             "@type": "Person",
             "name": "Louis Schlessinger",
-            "alternateName": "Lou Schlessinger",
+            "alternateName": ["Lou Schlessinger", "Louie Schlessinger"],
             "url": "https://louschlessinger.com/",
             "jobTitle": "Machine Learning Engineer",
+            "description": "Louis (Lou) Schlessinger is a machine learning engineer and researcher, and a Vesuvius Challenge Grand Prize runner-up. His work focuses on automated machine learning and meta-learning.",
             "alumniOf": {
                 "@type": "CollegeOrUniversity",
                 "name": "Washington University in St. Louis",
                 "url": "https://wustl.edu"
             },
-            "knowsAbout": ["Machine Learning", "Automated Machine Learning", "Meta-Learning", "AI", "Computer Science", "Physics"],
+            "knowsAbout": ["Machine Learning", "Automated Machine Learning", "Meta-Learning", "Deep Learning", "Computer Vision", "AI", "Computer Science", "Physics"],
             "sameAs": [
                 "https://github.com/lschlessinger1",
-                "https://www.linkedin.com/in/louschlessinger/"
+                "https://www.linkedin.com/in/louschlessinger/",
+                "https://huggingface.co/lschlessinger"
             ]
         }
         </script>
@@ -122,7 +124,7 @@
         <div class="container">
             <h2 class="display-4" id="about">About</h2>
             <p class="lead">Hello!</p>
-            <p class="lead">My name is Lou Schlessinger.</p>
+            <p class="lead">My name is <span aria-hidden="true">Lou<span class="name-muted">(is)</span></span><span class="visually-hidden">Louis</span> Schlessinger.</p>
             <p class="lead">
                 I was a student at <a href="https://wustl.edu">Washington University in St. Louis</a> studying
                 computer science and physics. I graduated in December 2018 with a B.S. and M.S. in computer science.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://louschlessinger.com/</loc>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## What & why

Polishes on-page and technical SEO for the portfolio, focused on **name discoverability** — making the site findable as "Louis", "Lou", and "Louie" Schlessinger. The site already had a strong foundation (canonical, OG/Twitter cards, JSON-LD `Person`, sitemap, robots, preloads); this fills the remaining gaps.

## Changes

- **`<title>`** → `Louis (Lou) Schlessinger — Machine Learning Engineer` (was just "Lou Schlessinger") — carries full name + nickname + role keywords.
- **Meta / OG / Twitter descriptions** rewritten from 39 → ~148 chars, with name variants, role, and the Vesuvius Challenge Grand Prize hook.
- **JSON-LD `Person`**: `alternateName` is now an array including **"Louie Schlessinger"**; added `description`, a Hugging Face `sameAs`, and `knowsAbout` terms (Deep Learning, Computer Vision).
- **About copy**: playful `Lou(is) Schlessinger`. The `(is)` is muted via a new theme-aware `--color-name-muted` token (WCAG AA contrast in both light and dark), with a `visually-hidden` "Louis" so screen readers announce the full name.
- Fixed `og:url` trailing slash to match canonical; `og:site_name` → "Louis Schlessinger".
- Added `<lastmod>` to `sitemap.xml`.

The visible H1 / navbar / intro intentionally keep **"Lou"** as the brand.

## Reviewer notes

- `npm run lint` (HTMLHint + ESLint) passes; JSON-LD validated as parseable.
- No `Person.image` added on purpose — there's no headshot, and pointing it at a project screenshot would risk a wrong Knowledge Panel photo.
- After merge + Pages redeploy: submit `https://louschlessinger.com/sitemap.xml` in Google Search Console and request indexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)