### PR TITLE
seo: pre-render project/research cards into static HTML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,8 @@ jobs:
 
       - name: Run linters
         run: npm run lint
+
+      - name: Verify rendered cards are in sync with data
+        run: |
+          npm run build
+          git diff --exit-code -- index.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,17 +17,18 @@ Personal portfolio website (louschlessinger.com) hosted on GitHub Pages. Static 
 - `npm run lint` — run all linters (HTMLHint + ESLint)
 - `npm run lint:html` — HTMLHint only
 - `npm run lint:js` — ESLint only
+- `npm run build` — render project/research cards from JSON into `index.html`
 - `node tools/generate-webp.js <image-paths>` — generate WebP variants
 
 ## Project Structure
 
 - `index.html` — single-page site with Bootstrap layout
 - `assets/css/main.css` — custom styles with CSS custom properties
-- `assets/js/main.js` — data fetching, rendering, interactivity
-- `assets/data/` — `projects.json` and `research.json` for dynamic content
+- `assets/js/main.js` — in-page navigation, scrollspy sync, copyright year
+- `assets/data/` — `projects.json` and `research.json`, rendered into `index.html` at build time
 - `assets/img/` — portfolio images (PNG/JPG with WebP variants)
 - `tools/` — Node.js utility scripts
-- `.github/workflows/ci.yml` — CI pipeline (lint on push/PR)
+- `.github/workflows/ci.yml` — CI pipeline (lint + content-sync check on push/PR)
 
 ## Conventions
 
@@ -35,11 +36,11 @@ Personal portfolio website (louschlessinger.com) hosted on GitHub Pages. Static 
 - ESLint 9.x flat config (`eslint.config.cjs`)
 - HTMLHint config (`.htmlhintrc`)
 - PRs target `master` branch
-- CI runs `npm ci && npm run lint` on Node.js 20
+- CI runs `npm ci && npm run lint` plus a build content-sync check on Node.js 20
 
 ## Key Patterns
 
-- Dynamic content loaded from JSON files with retry logic
+- Project/research cards rendered from JSON into static HTML at build time (`tools/build-content.js`)
 - WebP image optimization with fallback to original formats
 - Accessibility: ARIA attributes, prefers-reduced-motion support
 - Dark mode via `prefers-color-scheme`

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ lschlessinger1.github.io
 My personal website.
 
 This project is a static portfolio website built with HTML, CSS, and JavaScript, utilizing Bootstrap for styling and
-Font Awesome for icons. It dynamically loads project and research information from local JSON files (`projects.json`
-and `research.json`) to populate the respective sections of the site.
+Font Awesome for icons. Project and research information lives in local JSON files (`projects.json` and
+`research.json`) and is rendered into static HTML in `index.html` at build time via `npm run build`.
 
 Key features include:
 
 - Responsive design for various screen sizes.
 - Smooth scrolling for navigation.
-- Dynamic content loading for projects and research.
+- Build-time rendering of project and research cards from JSON.
 - Integration with Google Analytics and Microsoft Clarity for usage insights.
 
 ## Tooling
@@ -22,13 +22,15 @@ npm install
 npm run lint
 ```
 
+- `npm run build` — Render project/research cards from JSON into `index.html` (run after editing `assets/data/*.json`).
 - `npm run lint:html` — Validate HTML files with HTMLHint.
 - `npm run lint:js` — Lint `assets/js/` with ESLint (recommended ruleset, browser + latest ECMAScript).
 
 ## CI
 
 GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push to `master` and on pull requests. It installs
-Node.js 20, performs `npm ci`, and executes the lint suite to keep the static site healthy.
+Node.js 20, performs `npm ci`, executes the lint suite, and verifies `index.html` is in sync with the JSON data
+(by re-running `npm run build`) to keep the static site healthy.
 
 > **Note:** `npm ci` requires a committed `package-lock.json`. Include lockfile changes in commits when adjusting
 > dependencies so the workflow can run successfully.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,141 +1,14 @@
-const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-
-async function fetchData(type, retries = 3) {
-    const container = document.getElementById(`${type}-container`);
-    container.setAttribute('aria-busy', 'true');
-    for (let attempt = 1; attempt <= retries; attempt++) {
-        try {
-            const response = await fetch(`assets/data/${type}.json`);
-            if (!response.ok) {
-                console.error(`HTTP error! Status: ${response.status}`);
-                if (attempt < retries) {
-                    console.warn(`Retrying... (${attempt}/${retries})`);
-                    await delay(2000);
-                    continue;
-                }
-                showRetryError(container, type);
-                container.setAttribute('aria-busy', 'false');
-                return;
-            }
-            const data = await response.json();
-            if (!Array.isArray(data)) {
-                console.error(`Invalid JSON format: Expected an array for ${type}`);
-                container.innerHTML = `<p class='text-danger'>Invalid ${type} data format.</p>`;
-                container.setAttribute('aria-busy', 'false');
-                return;
-            }
-            renderItems(data, type);
-            container.setAttribute('aria-busy', 'false');
-            return;
-        } catch (error) {
-            console.error(`Error loading ${type}:`, error);
-            if (attempt < retries) {
-                console.warn(`Retrying... (${attempt}/${retries})`);
-                await delay(2000);
-            } else {
-                showRetryError(container, type);
-                container.setAttribute('aria-busy', 'false');
-            }
-        }
-    }
-}
-
-function showRetryError(container, type) {
-    container.innerHTML = '';
-    const wrapper = document.createElement('div');
-    wrapper.className = 'text-center';
-    const msg = document.createElement('p');
-    msg.className = 'text-danger';
-    msg.textContent = `Failed to load ${type}. Please try again later.`;
-    const btn = document.createElement('button');
-    btn.className = 'btn btn-outline-primary btn-sm mt-2';
-    btn.textContent = 'Retry';
-    btn.addEventListener('click', () => fetchData(type));
-    wrapper.appendChild(msg);
-    wrapper.appendChild(btn);
-    container.appendChild(wrapper);
-}
-
-// Build a WebP variant path for PNG/JPG sources. Every raster image in
-// assets/img/ has a same-basename .webp sibling (see tools/generate-webp.js),
-// so we emit the <source> unconditionally and rely on <picture> fallback.
-function webpVariant(src) {
-    return /\.(png|jpg|jpeg)$/i.test(src)
-        ? src.replace(/\.(png|jpg|jpeg)$/i, '.webp')
-        : null;
-}
-
-function escapeHTML(str) {
-    const div = document.createElement('div');
-    div.appendChild(document.createTextNode(str));
-    return div.innerHTML;
-}
-
-function renderItems(items, type) {
-    const container = document.getElementById(`${type}-container`);
-    container.innerHTML = ""; // Clear existing content
-
-    for (let i = 0; i < items.length; i += 2) {
-        let rowHTML = '<div class="row card-row">';
-
-        for (let j = 0; j < 2 && i + j < items.length; j++) {
-            const item = items[i + j];
-            if (!item.title || !item.description || !item.imgSrc || !item.link || !item.linkText) {
-                console.warn(`Skipping invalid ${type} entry:`, item);
-                continue;
-            }
-            const webp = webpVariant(item.imgSrc);
-            const webpSource = webp
-                ? `<source srcset="${encodeURI(webp)}" type="image/webp">`
-                : '';
-            // Performance hints: first row gets higher priority; others remain lazy & low priority
-            const isAboveFoldLikely = i === 0; // heuristic: first rendered row
-            const loadingAttr = isAboveFoldLikely ? 'loading="eager"' : 'loading="lazy"';
-            const fetchPriority = isAboveFoldLikely ? 'high' : 'low';
-            const sizesAttr = '(max-width: 768px) 100vw, 600px';
-            const safeTitle = escapeHTML(item.title);
-            const safeDesc = escapeHTML(item.description);
-            const safeAlt = escapeHTML(item.imgAlt || 'Image');
-            const safeSrc = encodeURI(item.imgSrc);
-            const safeLink = encodeURI(item.link);
-            const safeLinkText = escapeHTML(item.linkText);
-            rowHTML += `
-                <div class="col-md-5 ${j === 1 ? 'offset-md-2' : ''} mb-3">
-                    <div class="project-card">
-                        <div class="img-container">
-                            <picture>
-                                ${webpSource}
-                           <img alt="${safeAlt}"
-                               src="${safeSrc}" title="${safeTitle}" ${loadingAttr} width="600" height="300" decoding="async" fetchpriority="${fetchPriority}" sizes="${sizesAttr}"/>
-                            </picture>
-                        </div>
-                        <div class="card-body-inner">
-                            <p class="text-muted"><span class="fw-bold">${safeTitle}</span>&nbsp;&nbsp;
-                                ${safeDesc}</p>
-                            <div class="container text-center btn-container">
-                                <a class="btn btn-primary" href="${safeLink}" target="_blank" rel="noopener noreferrer">${safeLinkText}</a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            `;
-        }
-
-        rowHTML += '</div>';
-        container.insertAdjacentHTML("beforeend", rowHTML);
-    }
-}
+// Set the copyright year and wire up in-page navigation behavior.
+// Project and research cards are pre-rendered into index.html at build time
+// (see tools/build-content.js), so there is no client-side data fetching here.
 
 document.addEventListener("DOMContentLoaded", () => {
-    fetchData("projects").catch(error => console.error('Failed to fetch projects:', error));
-    fetchData("research").catch(error => console.error('Failed to fetch research:', error));
-
     // Set copyright year without document.write()
     const yearEl = document.getElementById('copyright-year');
     if (yearEl) yearEl.textContent = new Date().getFullYear();
 
-    // Native smooth scrolling handled via CSS (scroll-behavior: smooth)
-    // Add click delegation for in-page anchors to respect reduced motion preference
+    // Native smooth scrolling is handled via CSS (scroll-behavior: smooth).
+    // Delegate clicks on in-page anchors so we can respect reduced-motion.
     document.getElementById('main-navbar')?.addEventListener('click', (ev) => {
         const target = ev.target;
         if (target && target.closest) {

--- a/index.html
+++ b/index.html
@@ -57,10 +57,6 @@
 
     <!-- Preload LCP image (first research card) -->
     <link rel="preload" as="image" href="assets/img/patch_agg.webp" type="image/webp" fetchpriority="high">
-
-    <!-- Preload dynamic content JSON -->
-    <link rel="preload" as="fetch" href="assets/data/research.json" type="application/json" crossorigin>
-    <link rel="preload" as="fetch" href="assets/data/projects.json" type="application/json" crossorigin>
     <link href="assets/ico/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180">
     <link href="assets/ico/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">
     <link href="assets/ico/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png">
@@ -137,14 +133,344 @@
     <section id="research-section" aria-labelledby="research">
         <div class="container">
             <h2 class="display-4" id="research">Research</h2>
-            <div id="research-container" aria-busy="true" aria-live="polite"></div> <!-- Research will be inserted here -->
+            <div id="research-container">
+                <!-- build:research:start -->
+                <div class="row card-row">
+                    <div class="col-md-5 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/patch_agg.webp" type="image/webp">
+                                    <img alt="Vesuvius Challenge patch aggregation analysis" src="assets/img/patch_agg.png" title="Vesuvius Challenge Patch Aggregation Analysis" loading="eager" width="600" height="300" decoding="async" fetchpriority="high" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Vesuvius Challenge Patch Aggregation Analysis</span>&nbsp;&nbsp; A report on patch aggregation methods in ink detection for the Vesuvius Challenge. Awarded August, 2024 Progress Prize.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://github.com/lschlessinger1/vesuvius-patch-agg-analysis" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-5 offset-md-2 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/scroll.webp" type="image/webp">
+                                    <img alt="Scroll ink prediction" src="assets/img/scroll.png" title="Vesuvius Challenge Grand Prize (runner-up)" loading="eager" width="600" height="300" decoding="async" fetchpriority="high" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Vesuvius Challenge Grand Prize (runner-up)</span>&nbsp;&nbsp; A method to detect ink in carbonized micro-CT scans of the Herculaneum Papyri. Awarded runner-up in the 2023 Grand Prize.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://github.com/lschlessinger1/vesuvius-grand-prize-submission" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row card-row">
+                    <div class="col-md-5 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/curvature-preview.webp" type="image/webp">
+                                    <img alt="Scroll curvature" src="assets/img/curvature-preview.png" title="Vesuvius topogeo" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Vesuvius topogeo</span>&nbsp;&nbsp; A topological and geometric analysis comparing and contrasting scrolls and fragments from the Vesuvius Challenge to better understand domain differences.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://github.com/lschlessinger1/vesuvius-topogeo" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-5 offset-md-2 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/kernel_encoding_example.webp" type="image/webp">
+                                    <img alt="Compositional kernel encoding" src="assets/img/kernel_encoding_example.png" title="Automated Model Search Using Bayesian Optimization and Genetic Programming" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Automated Model Search Using Bayesian Optimization and Genetic Programming</span>&nbsp;&nbsp; Presented at the 3rd Workshop on Meta-Learning at NeurIPS 2019, Vancouver, Canada.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="http://metalearning.ml/2019/papers/metalearn2019-schlessinger.pdf" target="_blank" rel="noopener noreferrer">View paper</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row card-row">
+                    <div class="col-md-5 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/kernel_tree.webp" type="image/webp">
+                                    <img alt="Kernel tree" src="assets/img/kernel_tree.png" title="Automated Kernel Search using Evolutionary Algorithms" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Automated Kernel Search using Evolutionary Algorithms</span>&nbsp;&nbsp; Master&#39;s Project, Washington University in St. Louis, May 2019.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://github.com/lschlessinger1/MS-project/blob/master/reports/defense/report/project_report.pdf" target="_blank" rel="noopener noreferrer">View paper</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- build:research:end -->
+            </div>
         </div>
     </section>
 
     <section id="projects-section" aria-labelledby="projects">
         <div class="container">
             <h2 class="display-4" id="projects">Projects</h2>
-            <div id="projects-container" aria-busy="true" aria-live="polite"></div> <!-- Projects will be inserted here -->
+            <div id="projects-container">
+                <!-- build:projects:start -->
+                <div class="row card-row">
+                    <div class="col-md-5 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/occlusion_eval.webp" type="image/webp">
+                                    <img alt="Occlusion evaluation" src="assets/img/occlusion_eval.png" title="Occlusion evaluation" loading="eager" width="600" height="300" decoding="async" fetchpriority="high" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Occlusion evaluation</span>&nbsp;&nbsp; Simple experiments for creating occlusions in PyBullet and testing video prediction models like PredRNN.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://github.com/lschlessinger1/occlusion-eval" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-5 offset-md-2 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/math_prob_classification.webp" type="image/webp">
+                                    <img alt="Math problem classification" src="assets/img/math_prob_classification.png" title="Math Problem Classification" loading="eager" width="600" height="300" decoding="async" fetchpriority="high" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Math Problem Classification</span>&nbsp;&nbsp; A model to classify the category of a math problem. A fine-tuned version of bert-base-uncased on a subset of the MATH dataset.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://huggingface.co/lschlessinger/bert-finetuned-math-prob-classification" target="_blank" rel="noopener noreferrer">View on Hugging Face</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row card-row">
+                    <div class="col-md-5 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/usatt_rating_analyzer_demo.webp" type="image/webp">
+                                    <img alt="USATT rating analyzer demo" src="assets/img/usatt_rating_analyzer_demo.png" title="USATT Rating Analyzer" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">USATT Rating Analyzer</span>&nbsp;&nbsp; A Gradio web app that helps analyze USA Table Tennis (USATT) tournament and league results by providing basic statistics and performance visualizations over time.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://lschlessinger-usatt-rating-analyzer.hf.space" target="_blank" rel="noopener noreferrer">View Project</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-5 offset-md-2 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/traffickcam_main_activity.webp" type="image/webp">
+                                    <img alt="Traffickcam main activity screenshot" src="assets/img/traffickcam_main_activity.png" title="TraffickCam Android App" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">TraffickCam Android App</span>&nbsp;&nbsp; An app to help combat sex trafficking by allowing users to upload photos of hotel rooms they stay in. Developed for the Media and Machines Lab at Washington University in St. Louis.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://play.google.com/store/apps/details?id=com.exchangeinitiative.traffickcam" target="_blank" rel="noopener noreferrer">View on Google Play Store</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row card-row">
+                    <div class="col-md-5 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/snackhack.webp" type="image/webp">
+                                    <img alt="Snackhack dashboard" src="assets/img/snackhack.jpg" title="SnackHack" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">SnackHack</span>&nbsp;&nbsp; A web service and Android app that leverages Twitter&#39;s Geolocation API and WashU network data to provide real-time information on restaurant crowd levels on campus.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://devpost.com/software/snackhack" target="_blank" rel="noopener noreferrer">View Project</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-5 offset-md-2 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/choco_viz.webp" type="image/webp">
+                                    <img alt="Artisanal chocolate ratings bar chart" src="assets/img/choco_viz.png" title="Artisanal Chocolate Exploration" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Artisanal Chocolate Exploration</span>&nbsp;&nbsp; A D3 visualization of artisanal chocolate companies and ratings using expert review data from the Manhattan Chocolate Society.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="http://louschlessinger.com/Chocolate-Rating-Visualization/main.html" target="_blank" rel="noopener noreferrer">View Project</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row card-row">
+                    <div class="col-md-5 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/reddit_comm_detection.webp" type="image/webp">
+                                    <img alt="Reddit communities" src="assets/img/reddit_comm_detection.png" title="Reddit Community Detection" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Reddit Community Detection</span>&nbsp;&nbsp; A survey of community detection algorithms on Reddit data, based on the paper &#39;Detection and Analysis of Subreddit Communities&#39;.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://github.com/lschlessinger1/reddit-community-detection" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-5 offset-md-2 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/code.webp" type="image/webp">
+                                    <img alt="Generic image of code" src="assets/img/code.jpg" title="Algorithms" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Algorithms</span>&nbsp;&nbsp; A collection of algorithms implemented in various languages, covering topics from machine learning to multi-agent systems, including AdaBoost, neural networks, and the auction algorithm.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://github.com/lschlessinger1/Algorithms" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row card-row">
+                    <div class="col-md-5 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/stocks.webp" type="image/webp">
+                                    <img alt="Generic image of stocks" src="assets/img/stocks.png" title="Bayesian Stock Price Prediction" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Bayesian Stock Price Prediction</span>&nbsp;&nbsp; An evaluation of stock price prediction algorithms using analyst ratings.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://github.com/lschlessinger1/Bayesian-Stock-Price-Prediction" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-5 offset-md-2 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/electoral_map.webp" type="image/webp">
+                                    <img alt="Electoral map cartogram" src="assets/img/electoral_map.png" title="Electoral Map" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Electoral Map</span>&nbsp;&nbsp; A D3 cartogram of U.S. presidential elections ranging from 1940 to 2016.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://lschlessinger1.github.io/electoral-map/main.html" target="_blank" rel="noopener noreferrer">View Project</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row card-row">
+                    <div class="col-md-5 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/income.webp" type="image/webp">
+                                    <img alt="Correlation matrix of adult dataset" src="assets/img/income.png" title="Income Prediction" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Income Prediction</span>&nbsp;&nbsp; An evaluation of several machine learning methods applied to the Adult Data Set to predict income.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://github.com/lschlessinger1/Income-Prediction" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-5 offset-md-2 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/gtd_img.webp" type="image/webp">
+                                    <img alt="Global Terrorism Database clustering" src="assets/img/gtd_img.png" title="Global Terrorism Geo-Clustering in Spark" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Global Terrorism Geo-Clustering in Spark</span>&nbsp;&nbsp; A visualization of k-means clustering on terrorist attack locations using PySpark. Dataset contains 170,000+ terrorist attacks worldwide from 1970 to 2016.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://github.com/lschlessinger1/Global-Terrorism-Database-K-Means" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row card-row">
+                    <div class="col-md-5 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/fractal_terrain_img.webp" type="image/webp">
+                                    <img alt="Procedurally generated terrain" src="assets/img/fractal_terrain_img.png" title="Procedural Terrain Generation" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Procedural Terrain Generation</span>&nbsp;&nbsp; A WebGL rendering implementation of a terrain generator based on a 3D-projected terrain map. Uses the Diamond Square Algorithm to procedurally generate terrain.</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://lschlessinger1.github.io/fractalTerrainGeneration/main.html" target="_blank" rel="noopener noreferrer">View Project</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-5 offset-md-2 mb-3">
+                        <div class="project-card">
+                            <div class="img-container">
+                                <picture>
+                                    <source srcset="assets/img/image_quilting.webp" type="image/webp">
+                                    <img alt="Image quilting synthesis results" src="assets/img/image_quilting.png" title="Image Quilting" loading="lazy" width="600" height="300" decoding="async" fetchpriority="low" sizes="(max-width: 768px) 100vw, 600px"/>
+                                </picture>
+                            </div>
+                            <div class="card-body-inner">
+                                <p class="text-muted"><span class="fw-bold">Image Quilting</span>&nbsp;&nbsp; An implementation of &#39;Image Quilting for Texture Synthesis and Transfer&#39; (Elfros &amp; Freeman, 2001).</p>
+                                <div class="container text-center btn-container">
+                                    <a class="btn btn-primary" href="https://github.com/lschlessinger1/image-quilting" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- build:projects:end -->
+            </div>
         </div>
     </section>
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Personal portfolio static site.",
   "scripts": {
+    "build": "node tools/build-content.js",
     "lint:html": "htmlhint \"**/*.html\" --ignore node_modules",
     "lint:js": "eslint assets/js --max-warnings=0",
     "lint": "npm run lint:html && npm run lint:js"

--- a/tools/build-content.js
+++ b/tools/build-content.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/* eslint-env node */
+/*
+ * Pre-render the project and research cards from their JSON sources into
+ * static HTML inside index.html. The cards live between marker comments
+ * (<!-- build:<type>:start --> ... <!-- build:<type>:end -->) so the script
+ * is idempotent: re-running replaces the content between the markers.
+ *
+ * Run `npm run build` after editing assets/data/*.json. CI fails if the
+ * committed index.html is out of sync with the JSON (see ci.yml).
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const INDEX = path.join(ROOT, 'index.html');
+const SIZES = '(max-width: 768px) 100vw, 600px';
+
+const SOURCES = [
+    { type: 'research', json: path.join(ROOT, 'assets', 'data', 'research.json') },
+    { type: 'projects', json: path.join(ROOT, 'assets', 'data', 'projects.json') }
+];
+
+function escapeHtml(value) {
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+// URL-encode (mirrors the client's encodeURI) then make it attribute-safe.
+function attrUrl(value) {
+    return escapeHtml(encodeURI(String(value)));
+}
+
+// PNG/JPG sources have a same-basename .webp sibling (see generate-webp.js).
+function webpVariant(src) {
+    return /\.(png|jpe?g)$/i.test(src) ? src.replace(/\.(png|jpe?g)$/i, '.webp') : null;
+}
+
+function indent(block, spaces) {
+    const pad = ' '.repeat(spaces);
+    return block.split('\n').map(line => (line.length ? pad + line : line)).join('\n');
+}
+
+function isValid(item) {
+    return Boolean(item && item.title && item.description && item.imgSrc && item.link && item.linkText);
+}
+
+// `eager` marks the first row so its image matches the LCP preload in index.html.
+function renderCard(item, eager) {
+    const webp = webpVariant(item.imgSrc);
+    const loading = eager ? 'eager' : 'lazy';
+    const fetchPriority = eager ? 'high' : 'low';
+    const title = escapeHtml(item.title);
+    const alt = escapeHtml(item.imgAlt || 'Image');
+
+    const lines = [
+        '<div class="project-card">',
+        '    <div class="img-container">',
+        '        <picture>'
+    ];
+    if (webp) {
+        lines.push(`            <source srcset="${attrUrl(webp)}" type="image/webp">`);
+    }
+    lines.push(
+        `            <img alt="${alt}" src="${attrUrl(item.imgSrc)}" title="${title}" loading="${loading}" width="600" height="300" decoding="async" fetchpriority="${fetchPriority}" sizes="${SIZES}"/>`,
+        '        </picture>',
+        '    </div>',
+        '    <div class="card-body-inner">',
+        `        <p class="text-muted"><span class="fw-bold">${title}</span>&nbsp;&nbsp; ${escapeHtml(item.description)}</p>`,
+        '        <div class="container text-center btn-container">',
+        `            <a class="btn btn-primary" href="${attrUrl(item.link)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.linkText)}</a>`,
+        '        </div>',
+        '    </div>',
+        '</div>'
+    );
+    return lines.join('\n');
+}
+
+function renderRows(items) {
+    const valid = items.filter(isValid);
+    const rows = [];
+    for (let i = 0; i < valid.length; i += 2) {
+        const eager = i === 0;
+        const cols = [];
+        for (let j = 0; j < 2 && i + j < valid.length; j++) {
+            const offset = j === 1 ? ' offset-md-2' : '';
+            const card = indent(renderCard(valid[i + j], eager), 4);
+            cols.push(`<div class="col-md-5${offset} mb-3">\n${card}\n</div>`);
+        }
+        rows.push(`<div class="row card-row">\n${indent(cols.join('\n'), 4)}\n</div>`);
+    }
+    return rows.join('\n');
+}
+
+function inject(html, type, rendered, eol) {
+    const start = `<!-- build:${type}:start -->`;
+    const end = `<!-- build:${type}:end -->`;
+    const re = new RegExp(`(${start})[\\s\\S]*?(${end})`);
+    if (!re.test(html)) {
+        throw new Error(`Missing "${start} ... ${end}" markers in index.html`);
+    }
+    const body = indent(rendered, 16).split('\n').join(eol);
+    // Function replacement avoids `$` in card content being treated as a token.
+    return html.replace(re, (match, openMarker) => `${openMarker}${eol}${body}${eol}                ${end}`);
+}
+
+function main() {
+    let html = fs.readFileSync(INDEX, 'utf8');
+    const eol = html.includes('\r\n') ? '\r\n' : '\n';
+
+    for (const { type, json } of SOURCES) {
+        const data = JSON.parse(fs.readFileSync(json, 'utf8'));
+        if (!Array.isArray(data)) {
+            throw new Error(`Expected an array in ${path.relative(ROOT, json)}`);
+        }
+        const skipped = data.length - data.filter(isValid).length;
+        if (skipped > 0) {
+            console.warn(`Skipped ${skipped} invalid ${type} entr${skipped === 1 ? 'y' : 'ies'} (missing required fields)`);
+        }
+        html = inject(html, type, renderRows(data), eol);
+    }
+
+    fs.writeFileSync(INDEX, html);
+    console.log('Rendered research + projects cards into index.html');
+}
+
+main();


### PR DESCRIPTION
## What & why

Project and research cards were rendered client-side via `fetch()` + DOM injection. Google renders JS and indexes them, but **most non-Google crawlers — and notably AI bots (GPTBot, ClaudeBot, PerplexityBot, …) — don't execute JavaScript**, so they saw an empty shell and missed the entire project/research list.

This bakes the cards into `index.html` at build time, so the content is in the served HTML for every crawler. Bonus: faster first paint and no render flash, since there's no client-side fetch anymore.

## Changes

- **`tools/build-content.js`** — renders `assets/data/{research,projects}.json` into `index.html` between `<!-- build:*:start/end -->` markers. Idempotent and deterministic. Exposed as `npm run build`.
- **`assets/js/main.js`** — slimmed to nav smooth-scroll, scrollspy `aria-current` sync, and the copyright year. Removed the fetch / retry / render pipeline, so the card template now lives in exactly one place (the build script).
- **`index.html`** — cards baked in; removed the now-unused `<link rel="preload" as="fetch" … .json>` hints.
- **`.github/workflows/ci.yml`** — new step fails CI if `npm run build` leaves `index.html` out of sync with the JSON, so it can't go stale.
- **`package.json`** — `build` script.
- **`CLAUDE.md` / `README.md`** — documented the build step and workflow.

## New workflow

Edit `assets/data/*.json` → run `npm run build` → commit. CI enforces sync.

## Verification

- `npm run lint` (HTMLHint + ESLint) passes; the build is idempotent.
- With **JavaScript disabled** (simulating a non-JS crawler), the DOM contains all **19 cards** (5 research + 14 projects) and 19 `<img>` tags, and both sections render correctly.
- Served HTML over HTTP contains the cards with **zero `.json` references**.

No visual or behavioral change for users — identical card markup; the content now exists at load instead of after a fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)