### PR TITLE
chore: add Claude Code preview launch config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "static-site",
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["-m", "http.server", "4173"],
+      "port": 4173,
+      "autoPort": false
+    }
+  ]
+}


### PR DESCRIPTION
Adds `.claude/launch.json` so the project's local preview server can be launched via the Claude Code preview tool.

- **Server:** `static-site` — `python -m http.server` serving the site root (this is a static GitHub Pages site with no framework dev server).
- **Port 4173:** port 8000 is taken by the local Docker/WSL backend, so the config uses 4173.
- **`autoPort: false`:** `http.server` takes its port as a positional arg and ignores the `PORT` env var, so a fixed free port is used rather than auto-assignment.

Tooling-only; no changes to the site itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)