### PR TITLE
ux: reframe About around research through-line

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -82,7 +82,7 @@
     font-weight: bolder;
 }
 
-/* Muted "(is)" in the Lou(is) wordplay (About section) */
+/* Muted nickname aside, e.g. ("Lou"), in the About section */
 .name-muted {
     color: var(--color-name-muted);
 }

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
-    <meta name="description" content="Louis (Lou) Schlessinger — machine learning engineer and researcher, Vesuvius Challenge Grand Prize runner-up, focused on AutoML and meta-learning.">
+    <meta name="description" content="Louis (Lou) Schlessinger — machine learning engineer and researcher in mathematical reasoning, spatial cognition, and neuro-inspired AI. Vesuvius Challenge runner-up.">
     <link rel="canonical" href="https://louschlessinger.com/">
     <meta content="Louis Schlessinger" name="author">
     <meta name="theme-color" content="#111827">
@@ -22,7 +22,7 @@
     <!-- SEO & Open Graph -->
     <meta content="index, follow" name="robots">
     <meta content="Louis (Lou) Schlessinger — Machine Learning Engineer" property="og:title">
-    <meta content="Louis (Lou) Schlessinger — machine learning engineer and researcher, Vesuvius Challenge Grand Prize runner-up, focused on AutoML and meta-learning." property="og:description">
+    <meta content="Louis (Lou) Schlessinger — machine learning engineer and researcher in mathematical reasoning, spatial cognition, and neuro-inspired AI. Vesuvius Challenge runner-up." property="og:description">
     <meta content="https://louschlessinger.com/" property="og:url">
     <meta content="website" property="og:type">
     <meta content="https://louschlessinger.com/assets/img/scroll.png" property="og:image">
@@ -32,7 +32,7 @@
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Louis (Lou) Schlessinger — Machine Learning Engineer">
-    <meta name="twitter:description" content="Louis (Lou) Schlessinger — machine learning engineer and researcher, Vesuvius Challenge Grand Prize runner-up, focused on AutoML and meta-learning.">
+    <meta name="twitter:description" content="Louis (Lou) Schlessinger — machine learning engineer and researcher in mathematical reasoning, spatial cognition, and neuro-inspired AI. Vesuvius Challenge runner-up.">
     <meta name="twitter:image" content="https://louschlessinger.com/assets/img/scroll.png">
     <meta name="twitter:image:alt" content="Ink detection visualization from the Vesuvius Challenge Grand Prize runner-up submission.">
     <meta name="twitter:url" content="https://louschlessinger.com/">
@@ -73,13 +73,13 @@
             "alternateName": ["Lou Schlessinger", "Louie Schlessinger"],
             "url": "https://louschlessinger.com/",
             "jobTitle": "Machine Learning Engineer",
-            "description": "Louis (Lou) Schlessinger is a machine learning engineer and researcher, and a Vesuvius Challenge Grand Prize runner-up. His work focuses on automated machine learning and meta-learning.",
+            "description": "Louis (Lou) Schlessinger is a machine learning engineer and researcher in mathematical reasoning, spatial cognition, computer vision, and neuro-inspired AI, exploring how intelligent systems learn, reason, and build internal representations of the world. Runner-up for the 2023 Vesuvius Challenge Grand Prize.",
             "alumniOf": {
                 "@type": "CollegeOrUniversity",
                 "name": "Washington University in St. Louis",
                 "url": "https://wustl.edu"
             },
-            "knowsAbout": ["Machine Learning", "Automated Machine Learning", "Meta-Learning", "Deep Learning", "Computer Vision", "AI", "Computer Science", "Physics"],
+            "knowsAbout": ["Machine Learning", "Computer Vision", "Mathematical Reasoning", "Spatial Cognition", "Neuro-inspired AI", "Representation Learning", "Deep Learning", "Automated Machine Learning", "Meta-Learning", "AI", "Computer Science", "Physics"],
             "sameAs": [
                 "https://github.com/lschlessinger1",
                 "https://www.linkedin.com/in/louschlessinger/",
@@ -123,13 +123,18 @@
     <section id="about-section" aria-labelledby="about">
         <div class="container">
             <h2 class="display-4" id="about">About</h2>
-            <p class="lead">Hello!</p>
-            <p class="lead">My name is <span aria-hidden="true">Lou<span class="name-muted">(is)</span></span><span class="visually-hidden">Louis</span> Schlessinger.</p>
             <p class="lead">
-                I was a student at <a href="https://wustl.edu">Washington University in St. Louis</a> studying
-                computer science and physics. I graduated in December 2018 with a B.S. and M.S. in computer science.
-                My primary research interests are in <strong>automated machine learning</strong>,
-                <strong>meta-learning</strong>, and the intersection of <strong>AI and quantitative reasoning</strong>.
+                I'm Louis <span class="name-muted">("Lou")</span> Schlessinger, a machine learning engineer and
+                researcher interested in <strong>mathematical reasoning</strong>, <strong>spatial cognition</strong>,
+                and <strong>neuro-inspired AI</strong>. I currently work on projects exploring how intelligent
+                systems learn, reason, and build internal representations of the world.
+            </p>
+            <p class="lead">
+                A few things about me: I led the team that placed runner-up for the 2023
+                <strong>Vesuvius Challenge</strong> Grand Prize, presented work on automated model search at the
+                NeurIPS Meta-Learning workshop, and have built large-scale multimodal ML systems in production. I
+                hold B.S. and M.S. degrees in computer science from
+                <a href="https://wustl.edu">Washington University in St. Louis</a>.
             </p>
         </div>
     </section>


### PR DESCRIPTION
Rewrites the homepage **About** to lead with a work-centered through-line rather than a chronological bio, and folds key background into a single "a few things about me" paragraph instead of separate CV-style sections.

## Changes

- **About copy** — evergreen intro (mathematical reasoning, spatial cognition, neuro-inspired AI; how intelligent systems learn, reason, and build internal representations of the world), followed by a non-exhaustive "a few things about me" paragraph: Vesuvius Challenge Grand Prize runner-up (team lead), automated-model-search work at the NeurIPS Meta-Learning workshop, production multimodal ML, and WashU B.S./M.S. The "(Lou)" nickname reuses the existing muted-aside style.
- **JSON-LD `Person`** — `description` + `knowsAbout` aligned to the new positioning.
- **`meta`/OG/Twitter `description`** — aligned to match (was "AutoML and meta-learning").
- **`main.css`** — one-line comment fix for `.name-muted` (no longer the "(is)" wordplay).

## Notes

- Header/nav/brand unchanged ("Lou Schlessinger"); no new sections — work detail lives in the existing Research/Projects sections and structured data.
- Employer is intentionally not named; production work is described generically.
- `npm run lint` (HTMLHint + ESLint) passes; JSON-LD validated as parseable.
- Independent of the pre-render PR (#19) and the launch-config PR (#20) — touches different regions; merges cleanly in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)